### PR TITLE
Fix write corruption (non-4-byte-aligned)

### DIFF
--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -97,7 +97,7 @@ import {
   ESP32P4_PMU_DATE_REG,
 } from "./const";
 import { getStubCode } from "./stubs";
-import { hexFormatter, sleep, slipEncode, toHex } from "./util";
+import { hexFormatter, padTo, sleep, slipEncode, toHex } from "./util";
 import { deflate } from "pako";
 import { pack, unpack } from "./struct";
 
@@ -2419,6 +2419,9 @@ export class ESPLoader extends EventTarget {
         )}, FlashSizeFreq=${toHex(headerFlashSizeFreq)}`,
       );
     }
+
+    const paddedData = padTo(new Uint8Array(binaryData), 4);
+    binaryData = paddedData.buffer;
 
     const uncompressedFilesize = binaryData.byteLength;
     let compressedFilesize = 0;

--- a/src/esp_loader.ts
+++ b/src/esp_loader.ts
@@ -2421,7 +2421,7 @@ export class ESPLoader extends EventTarget {
     }
 
     const paddedData = padTo(new Uint8Array(binaryData), 4);
-    binaryData = paddedData.buffer;
+    binaryData = paddedData.buffer as ArrayBuffer;
 
     const uncompressedFilesize = binaryData.byteLength;
     let compressedFilesize = 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,7 +58,11 @@ export const formatMacAddr = (macAddr: number[]): string => {
  * @name padTo
  * Pad data to the next alignment boundary with the given fill byte (default 0xFF)
  */
-export function padTo(data: Uint8Array, alignment: number, padCharacter = 0xff): Uint8Array {
+export function padTo(
+  data: Uint8Array,
+  alignment: number,
+  padCharacter = 0xff,
+): Uint8Array {
   const padMod = data.length % alignment;
   if (padMod !== 0) {
     const padding = new Uint8Array(alignment - padMod).fill(padCharacter);

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,5 +54,21 @@ export const formatMacAddr = (macAddr: number[]): string => {
     .join(":");
 };
 
+/**
+ * @name padTo
+ * Pad data to the next alignment boundary with the given fill byte (default 0xFF)
+ */
+export function padTo(data: Uint8Array, alignment: number, padCharacter = 0xff): Uint8Array {
+  const padMod = data.length % alignment;
+  if (padMod !== 0) {
+    const padding = new Uint8Array(alignment - padMod).fill(padCharacter);
+    const paddedData = new Uint8Array(data.length + padding.length);
+    paddedData.set(data);
+    paddedData.set(padding, data.length);
+    return paddedData;
+  }
+  return data;
+}
+
 export const sleep = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Flash write operations on ESP chips require data to be 4-byte (word) aligned. When a firmware image size is not a multiple of 4, the unaligned trailing bytes can cause write failures on both compressed and uncompressed flash paths.

This adds a padTo() utility (matching upstream convention) and pads binary data to 4-byte alignment with 0xFF at the start of flashData(), before compression or size calculations. Padding with 0xFF matches erased-flash semantics and is consistent with existing last-block padding behavior.

See https://github.com/espressif/esptool-js/blob/0d801f7bff0b07db0a251f38af679b09180f80d2/src/esploader.ts#L1534

Reproducable flash corruption on esp32c3 - luckily the img had partition checksumming at runtime and caught this - verified that PR fixes the corruption.

Also verified corruption with esptool.py and verified fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware flashing reliability by ensuring binary data is aligned to 4‑byte boundaries before flashing, reducing flash errors across devices and configurations.
* **Chores**
  * Added an internal data‑padding utility to support alignment.
* **Notes**
  * No user-facing API or behavior changes beyond more reliable flashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->